### PR TITLE
chore: use `mdc-syntax` to render chats

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "defu": "^6.1.4",
     "drizzle-orm": "^0.45.1",
     "katex": "^0.16.28",
+    "mdc-syntax": "https://pkg.pr.new/nuxt-content/mdc-syntax@3702c17",
     "mermaid": "^11.12.2",
     "nitro": "npm:nitro-nightly@latest",
     "ofetch": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "ufo": "^1.6.3",
     "vue": "^3.5.28",
     "vue-chrts": "^1.0.2",
-    "vue-renderer-markdown": "0.0.62",
     "vue-router": "^4.6.4",
     "vue-use-monaco": "^0.0.33",
     "zod": "^4.3.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,9 +74,6 @@ importers:
       vue-chrts:
         specifier: ^1.0.2
         version: 1.0.2(vue@3.5.28(typescript@5.9.3))
-      vue-renderer-markdown:
-        specifier: 0.0.62
-        version: 0.0.62(katex@0.16.28)(mermaid@11.12.2)(shiki@3.22.0)(vue@3.5.28(typescript@5.9.3))
       vue-router:
         specifier: ^4.6.4
         version: 4.6.4(vue@3.5.28(typescript@5.9.3))
@@ -3380,39 +3377,11 @@ packages:
   maplibre-gl@2.4.0:
     resolution: {integrity: sha512-csNFylzntPmHWidczfgCZpvbTSmhaWvLRj9e1ezUDBEPizGgshgm3ea1T5TCNEEBq0roauu7BPuRZjA3wO4KqA==}
 
-  markdown-it-container@4.0.0:
-    resolution: {integrity: sha512-HaNccxUH0l7BNGYbFbjmGpf5aLHAMTinqRZQAEQbMr2cdD3z91Q6kIo1oUn1CQndkT03jat6ckrdRYuwwqLlQw==}
-
-  markdown-it-emoji@3.0.0:
-    resolution: {integrity: sha512-+rUD93bXHubA4arpEZO3q80so0qgoFJEKRkRbjKX8RTdca89v2kfyF+xR3i2sQTwql9tpPZPOQN5B+PunspXRg==}
-
-  markdown-it-footnote@4.0.0:
-    resolution: {integrity: sha512-WYJ7urf+khJYl3DqofQpYfEYkZKbmXmwxQV8c8mO/hGIhgZ1wOe7R4HLFNwqx7TjILbnC98fuyeSsin19JdFcQ==}
-
-  markdown-it-ins@4.0.0:
-    resolution: {integrity: sha512-sWbjK2DprrkINE4oYDhHdCijGT+MIDhEupjSHLXe5UXeVr5qmVxs/nTUVtgi0Oh/qtF+QKV0tNWDhQBEPxiMew==}
-
-  markdown-it-mark@4.0.0:
-    resolution: {integrity: sha512-YLhzaOsU9THO/cal0lUjfMjrqSMPjjyjChYM7oyj4DnyaXEzA8gnW6cVJeyCrCVeyesrY2PlEdUYJSPFYL4Nkg==}
-
   markdown-it-mdc@0.2.10:
     resolution: {integrity: sha512-DEZTbc2OJqA0pjxWAYEje2Hl35EwPB80moqcIcB/axgH77WbVdyWEqdJ/jbYN5fZlxZgqDxc9SdBGLulRy+A1Q==}
     peerDependencies:
       '@types/markdown-it': '*'
       markdown-it: ^14.0.0
-
-  markdown-it-sub@2.0.0:
-    resolution: {integrity: sha512-iCBKgwCkfQBRg2vApy9vx1C1Tu6D8XYo8NvevI3OlwzBRmiMtsJ2sXupBgEA7PPxiDwNni3qIUkhZ6j5wofDUA==}
-
-  markdown-it-sup@2.0.0:
-    resolution: {integrity: sha512-5VgmdKlkBd8sgXuoDoxMpiU+BiEt3I49GItBzzw7Mxq9CxvnhE/k09HFli09zgfFDRixDQDfDxi0mgBCXtaTvA==}
-
-  markdown-it-task-checkbox@1.0.6:
-    resolution: {integrity: sha512-7pxkHuvqTOu3iwVGmDPeYjQg+AIS9VQxzyLP9JCg9lBjgPAJXGEkChK6A2iFuj3tS0GV3HG2u5AMNhcQqwxpJw==}
-
-  markdown-it-ts@0.0.2-beta.4:
-    resolution: {integrity: sha512-IODjyQuedEjZkUoILLHOvPvG1CEyDECr8bja5VLTwQ2UD0wGSA9guNrD+ko8t5LLR1dglcBTEsMw9iYt7Ngrsg==}
-    engines: {node: '>=18'}
 
   markdown-it@14.1.0:
     resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
@@ -4028,9 +3997,6 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
-  stream-markdown-parser@0.0.28:
-    resolution: {integrity: sha512-QHOJrRZ8gD/y9ZBuNHgLYo6bh/cngfEGPpSamO7VrCVR+CrTrPjSeYhRGy44jpHv/f71W6emaUat7lNes0TWyQ==}
-
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
@@ -4541,31 +4507,6 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
-
-  vue-renderer-markdown@0.0.62:
-    resolution: {integrity: sha512-zav0x2vcJXx0VYIZwS7/pd+/duYa7PdaG4JkUpGAT/GzXzovSXkIS/j3mIt2WcOgmSDGcZnVqCt8MGFNco94XQ==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
-    peerDependencies:
-      katex: '>=0.16.22'
-      mermaid: '>=11'
-      shiki: ^3.13.0
-      stream-markdown: '>=0.0.9'
-      stream-monaco: '>=0.0.2'
-      vue: '>=3.0.0'
-      vue-i18n: '>=9'
-    peerDependenciesMeta:
-      katex:
-        optional: true
-      mermaid:
-        optional: true
-      shiki:
-        optional: true
-      stream-markdown:
-        optional: true
-      stream-monaco:
-        optional: true
-      vue-i18n:
-        optional: true
 
   vue-router@4.6.4:
     resolution: {integrity: sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==}
@@ -7975,35 +7916,11 @@ snapshots:
       tinyqueue: 2.0.3
       vt-pbf: 3.1.3
 
-  markdown-it-container@4.0.0: {}
-
-  markdown-it-emoji@3.0.0: {}
-
-  markdown-it-footnote@4.0.0: {}
-
-  markdown-it-ins@4.0.0: {}
-
-  markdown-it-mark@4.0.0: {}
-
   markdown-it-mdc@0.2.10(@types/markdown-it@14.1.2)(markdown-it@14.1.0):
     dependencies:
       '@types/markdown-it': 14.1.2
       markdown-it: 14.1.0
       yaml: 2.8.2
-
-  markdown-it-sub@2.0.0: {}
-
-  markdown-it-sup@2.0.0: {}
-
-  markdown-it-task-checkbox@1.0.6: {}
-
-  markdown-it-ts@0.0.2-beta.4:
-    dependencies:
-      entities: 4.5.0
-      linkify-it: 5.0.0
-      mdurl: 2.0.0
-      punycode.js: 2.3.1
-      uc.micro: 2.1.0
 
   markdown-it@14.1.0:
     dependencies:
@@ -8711,18 +8628,6 @@ snapshots:
 
   std-env@3.10.0: {}
 
-  stream-markdown-parser@0.0.28:
-    dependencies:
-      markdown-it-container: 4.0.0
-      markdown-it-emoji: 3.0.0
-      markdown-it-footnote: 4.0.0
-      markdown-it-ins: 4.0.0
-      markdown-it-mark: 4.0.0
-      markdown-it-sub: 2.0.0
-      markdown-it-sup: 2.0.0
-      markdown-it-task-checkbox: 1.0.6
-      markdown-it-ts: 0.0.2-beta.4
-
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
@@ -9154,16 +9059,6 @@ snapshots:
       semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
-
-  vue-renderer-markdown@0.0.62(katex@0.16.28)(mermaid@11.12.2)(shiki@3.22.0)(vue@3.5.28(typescript@5.9.3)):
-    dependencies:
-      '@floating-ui/dom': 1.7.4
-      stream-markdown-parser: 0.0.28
-      vue: 3.5.28(typescript@5.9.3)
-    optionalDependencies:
-      katex: 0.16.28
-      mermaid: 11.12.2
-      shiki: 3.22.0
 
   vue-router@4.6.4(vue@3.5.28(typescript@5.9.3)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       katex:
         specifier: ^0.16.28
         version: 0.16.28
+      mdc-syntax:
+        specifier: https://pkg.pr.new/nuxt-content/mdc-syntax@3702c17
+        version: https://pkg.pr.new/nuxt-content/mdc-syntax@3702c17(@types/markdown-it@14.1.2)(vue@3.5.28(typescript@5.9.3))
       mermaid:
         specifier: ^11.12.2
         version: 11.12.2
@@ -3108,6 +3111,10 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
@@ -3388,6 +3395,12 @@ packages:
   markdown-it-mark@4.0.0:
     resolution: {integrity: sha512-YLhzaOsU9THO/cal0lUjfMjrqSMPjjyjChYM7oyj4DnyaXEzA8gnW6cVJeyCrCVeyesrY2PlEdUYJSPFYL4Nkg==}
 
+  markdown-it-mdc@0.2.10:
+    resolution: {integrity: sha512-DEZTbc2OJqA0pjxWAYEje2Hl35EwPB80moqcIcB/axgH77WbVdyWEqdJ/jbYN5fZlxZgqDxc9SdBGLulRy+A1Q==}
+    peerDependencies:
+      '@types/markdown-it': '*'
+      markdown-it: ^14.0.0
+
   markdown-it-sub@2.0.0:
     resolution: {integrity: sha512-iCBKgwCkfQBRg2vApy9vx1C1Tu6D8XYo8NvevI3OlwzBRmiMtsJ2sXupBgEA7PPxiDwNni3qIUkhZ6j5wofDUA==}
 
@@ -3417,6 +3430,18 @@ packages:
 
   mdast-util-to-hast@13.2.1:
     resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdc-syntax@https://pkg.pr.new/nuxt-content/mdc-syntax@3702c17:
+    resolution: {integrity: sha512-8U3iVuGbagCjWgob6cXwWW+EWnKAd/I5ssWNEPi98AnkeioiJDBEf/mNX/QHETDgbgLOf0ST+GZGoQziRw8kUw==, tarball: https://pkg.pr.new/nuxt-content/mdc-syntax@3702c17}
+    version: 0.0.1
+    peerDependencies:
+      react: ^19.2.4
+      vue: ^3.5.27
+    peerDependenciesMeta:
+      react:
+        optional: true
+      vue:
+        optional: true
 
   mdn-data@2.12.2:
     resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
@@ -3456,6 +3481,9 @@ packages:
   mimic-fn@4.0.0:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
+
+  minimark@1.0.0:
+    resolution: {integrity: sha512-4maJvB7opKTzIWeh0jIpWf6FbN/nU3UjsjDnlLuYixnLp4laKoQrCYfmKA71Qm+EV3SUsKvawO+1EBiu11+kBg==}
 
   minimatch@10.1.2:
     resolution: {integrity: sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==}
@@ -7715,6 +7743,10 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
@@ -7953,6 +7985,12 @@ snapshots:
 
   markdown-it-mark@4.0.0: {}
 
+  markdown-it-mdc@0.2.10(@types/markdown-it@14.1.2)(markdown-it@14.1.0):
+    dependencies:
+      '@types/markdown-it': 14.1.2
+      markdown-it: 14.1.0
+      yaml: 2.8.2
+
   markdown-it-sub@2.0.0: {}
 
   markdown-it-sup@2.0.0: {}
@@ -7991,6 +8029,20 @@ snapshots:
       unist-util-position: 5.0.0
       unist-util-visit: 5.0.0
       vfile: 6.0.3
+
+  mdc-syntax@https://pkg.pr.new/nuxt-content/mdc-syntax@3702c17(@types/markdown-it@14.1.2)(vue@3.5.28(typescript@5.9.3)):
+    dependencies:
+      markdown-it: 14.1.0
+      markdown-it-mdc: 0.2.10(@types/markdown-it@14.1.2)(markdown-it@14.1.0)
+      minimark: 1.0.0
+      shiki: 3.22.0
+      shiki-stream: 0.1.4(vue@3.5.28(typescript@5.9.3))
+      yaml: 2.8.2
+    optionalDependencies:
+      vue: 3.5.28(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@types/markdown-it'
+      - solid-js
 
   mdn-data@2.12.2: {}
 
@@ -8046,6 +8098,11 @@ snapshots:
       picomatch: 2.3.1
 
   mimic-fn@4.0.0: {}
+
+  minimark@1.0.0:
+    dependencies:
+      entities: 7.0.1
+      js-yaml: 4.1.1
 
   minimatch@10.1.2:
     dependencies:

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -1,6 +1,8 @@
 @import "tailwindcss" theme(static);
 @import "@nuxt/ui";
 
+@source "../../../node_modules/mdc-syntax/dist/**/*.vue";
+
 @theme static {
   --font-sans: 'Public Sans', sans-serif;
 

--- a/src/pages/chat/[id].vue
+++ b/src/pages/chat/[id].vue
@@ -9,12 +9,12 @@ import { getTextFromMessage } from '@nuxt/ui/utils/ai'
 import { useModels } from '../../composables/useModels'
 import { useChats } from '../../composables/useChats'
 import { useRoute } from 'vue-router'
-import MarkdownRender from 'vue-renderer-markdown'
 import type { WeatherUIToolInvocation } from '../../../server/utils/tools/weather'
 import type { ChartUIToolInvocation } from '../../../server/utils/tools/chart'
 import ToolWeather from '../../components/tool/ToolWeather.vue'
 import ToolChart from '../../components/tool/ToolChart.vue'
 import Reasoning from '../../components/Reasoning.vue'
+import { MDC } from 'mdc-syntax/vue'
 
 const route = useRoute<'/chat/[id]'>()
 const toast = useToast()
@@ -116,9 +116,16 @@ onMounted(() => {
                 :is-streaming="part.state !== 'done'"
               />
               <!-- Only render markdown for assistant messages to prevent XSS from user input -->
-              <MarkdownRender
+              <MDC
                 v-else-if="part.type === 'text' && message.role === 'assistant'"
-                :content="getTextFromMessage(message)"
+                :markdown="getTextFromMessage(message)"
+                :streaming="part.state === 'streaming'"
+                caret
+                :options="{
+                  highlight: {
+                    themes: { light: 'material-theme-palenight', dark: 'material-theme-lighter' },
+                  }
+                }"
               />
               <!-- User messages are rendered as plain text (safely escaped by Vue) -->
               <p

--- a/src/pages/chat/[id].vue
+++ b/src/pages/chat/[id].vue
@@ -108,7 +108,7 @@ onMounted(() => {
           <template #content="{ message }">
             <template
               v-for="(part, index) in message.parts"
-              :key="`${message.id}-${part.type}-${index}${'state' in part ? `-${part.state}` : ''}`"
+              :key="`${message.id}-${part.type}-${index}`"
             >
               <Reasoning
                 v-if="part.type === 'reasoning'"


### PR DESCRIPTION
This PR shows how we can use `mdc-syntax` markdown renderer in chat

Note: this is very simple usage for now, and `mdc-syntax` uses its built-in typography components. The Nuxt component will integrate with Nuxt UI.