### PR TITLE
feat: add CSRF protection and validate models

### DIFF
--- a/server/middleware/csrf.ts
+++ b/server/middleware/csrf.ts
@@ -1,0 +1,27 @@
+import { defineEventHandler, getCookie, setCookie, getRequestHeader, HTTPError } from 'nitro/h3'
+import { randomUUID } from 'node:crypto'
+
+const CSRF_COOKIE = 'csrf-token'
+const CSRF_HEADER = 'x-csrf-token'
+const SAFE_METHODS = ['GET', 'HEAD', 'OPTIONS']
+
+export default defineEventHandler((event) => {
+  let token = getCookie(event, CSRF_COOKIE)
+
+  if (!token) {
+    token = randomUUID()
+    setCookie(event, CSRF_COOKIE, token, {
+      httpOnly: false,
+      sameSite: 'strict',
+      secure: process.env.NODE_ENV === 'production',
+      path: '/'
+    })
+  }
+
+  if (!SAFE_METHODS.includes(event.method)) {
+    const headerToken = getRequestHeader(event, CSRF_HEADER)
+    if (!headerToken || headerToken !== token) {
+      throw new HTTPError({ statusCode: 403, statusMessage: 'CSRF token mismatch' })
+    }
+  }
+})

--- a/server/routes/api/chats/[id].post.ts
+++ b/server/routes/api/chats/[id].post.ts
@@ -7,6 +7,7 @@ import { useDrizzle, tables, eq, and } from '../../../utils/drizzle'
 import { defineEventHandler, getValidatedRouterParams, readValidatedBody, HTTPError } from 'nitro/h3'
 import { weatherTool } from '../../../utils/tools/weather'
 import { chartTool } from '../../../utils/tools/chart'
+import { MODELS } from '../../../../shared/utils/models'
 
 export default defineEventHandler(async (event) => {
   const session = await useUserSession(event)
@@ -16,7 +17,9 @@ export default defineEventHandler(async (event) => {
   }).parse)
 
   const { model, messages } = await readValidatedBody(event, z.object({
-    model: z.string(),
+    model: z.string().refine(value => MODELS.some(m => m.value === value), {
+      message: 'Invalid model'
+    }),
     messages: z.array(z.custom<UIMessage>())
   }).parse)
 

--- a/shared/utils/models.ts
+++ b/shared/utils/models.ts
@@ -1,0 +1,5 @@
+export const MODELS = [
+  { label: 'GPT-5 Nano', value: 'openai/gpt-5-nano', icon: 'i-simple-icons:openai' },
+  { label: 'Claude Haiku 4.5', value: 'anthropic/claude-haiku-4.5', icon: 'i-simple-icons:anthropic' },
+  { label: 'Gemini 3 Flash', value: 'google/gemini-3-flash', icon: 'i-simple-icons:google' }
+]

--- a/src/composables/useCsrf.ts
+++ b/src/composables/useCsrf.ts
@@ -1,0 +1,14 @@
+const CSRF_COOKIE = 'csrf-token'
+const CSRF_HEADER = 'x-csrf-token'
+
+function getCsrfToken(): string {
+  const match = document.cookie.match(new RegExp(`(?:^|; )${CSRF_COOKIE}=([^;]*)`))
+  return match?.[1] ?? ''
+}
+
+export function useCsrf() {
+  return {
+    csrf: getCsrfToken,
+    headerName: CSRF_HEADER
+  }
+}

--- a/src/composables/useModels.ts
+++ b/src/composables/useModels.ts
@@ -1,16 +1,11 @@
 import { useStorage } from '@vueuse/core'
+import { MODELS } from '../../shared/utils/models'
 
 export function useModels() {
-  const models = [
-    { label: 'GPT-5 Nano', value: 'openai/gpt-5-nano', icon: 'i-simple-icons:openai' },
-    { label: 'Claude Haiku 4.5', value: 'anthropic/claude-haiku-4.5', icon: 'i-simple-icons:anthropic' },
-    { label: 'Gemini 3 Flash', value: 'google/gemini-3-flash', icon: 'i-simple-icons:google' }
-  ]
-
   const model = useStorage<string>('model', 'openai/gpt-5-nano')
 
   return {
-    models,
+    models: MODELS,
     model
   }
 }

--- a/src/composables/useUserSession.ts
+++ b/src/composables/useUserSession.ts
@@ -2,13 +2,16 @@ import { createSharedComposable } from '@vueuse/core'
 import { ref, computed } from 'vue'
 import type { UserSession } from '../../server/utils/session'
 import { $fetch } from 'ofetch'
+import { useCsrf } from './useCsrf'
 
 export const useUserSession = createSharedComposable(() => {
   const session = ref<UserSession | null>(null)
+  const { csrf, headerName } = useCsrf()
 
   const clearSession = async () => {
     await $fetch('/api/session', {
       method: 'DELETE',
+      headers: { [headerName]: csrf() }
     })
     session.value = null
   }

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -6,12 +6,14 @@ import { $fetch } from 'ofetch'
 import ModalConfirm from '../components/ModalConfirm.vue'
 import { useChats } from '../composables/useChats'
 import { useUserSession } from '../composables/useUserSession'
+import { useCsrf } from '../composables/useCsrf'
 
 const router = useRouter()
 const route = useRoute<'/chat/[id]' | '/'>()
 const toast = useToast()
 const overlay = useOverlay()
 const { loggedIn, openInPopup, fetchSession } = useUserSession()
+const { csrf, headerName } = useCsrf()
 const { groups, fetchChats } = useChats()
 
 await fetchSession()
@@ -51,7 +53,10 @@ async function deleteChat(id: string) {
     return
   }
 
-  await $fetch(`/api/chats/${id}`, { method: 'DELETE' })
+  await $fetch(`/api/chats/${id}`, {
+    method: 'DELETE',
+    headers: { [headerName]: csrf() }
+  })
 
   toast.add({
     title: 'Chat deleted',

--- a/src/pages/chat/[id].vue
+++ b/src/pages/chat/[id].vue
@@ -8,6 +8,7 @@ import { useClipboard } from '@vueuse/core'
 import { getTextFromMessage } from '@nuxt/ui/utils/ai'
 import { useModels } from '../../composables/useModels'
 import { useChats } from '../../composables/useChats'
+import { useCsrf } from '../../composables/useCsrf'
 import { useRoute } from 'vue-router'
 import MarkdownRender from 'vue-renderer-markdown'
 import type { WeatherUIToolInvocation } from '../../../server/utils/tools/weather'
@@ -21,6 +22,7 @@ const toast = useToast()
 const clipboard = useClipboard()
 const { model } = useModels()
 const { fetchChats } = useChats()
+const { csrf, headerName } = useCsrf()
 
 const chatData = await $fetch(`/api/chats/${route.params.id}`)
 
@@ -35,6 +37,7 @@ const chat = new Chat({
   messages: chatData.messages,
   transport: new DefaultChatTransport({
     api: `/api/chats/${chatData.id}`,
+    headers: { [headerName]: csrf() },
     body: {
       model: model.value
     }

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -2,9 +2,11 @@
 import { ref } from 'vue'
 import { $fetch } from 'ofetch'
 import { useChats } from '../composables/useChats'
+import { useCsrf } from '../composables/useCsrf'
 import { useRouter } from 'vue-router'
 
 const { fetchChats } = useChats()
+const { csrf, headerName } = useCsrf()
 const input = ref('')
 const loading = ref(false)
 const router = useRouter()
@@ -14,6 +16,7 @@ async function createChat(prompt: string) {
   loading.value = true
   const chat = await $fetch('/api/chats', {
     method: 'POST',
+    headers: { [headerName]: csrf() },
     body: { input: prompt }
   })
 


### PR DESCRIPTION
## Summary

- Add Nitro server middleware for CSRF protection using the double-submit cookie pattern (replaces `nuxt-csurf` from the Nuxt version).
- Securely validate the `model` parameter against a centralized allowed list.
- Centralize model definitions in `shared/utils/models.ts` shared between server and client.

## Test plan

- [ ] Verify that standard app interactions (creating, messaging, and deleting a chat) succeed.
- [ ] Verify that the network requests properly attach the generated CSRF token.
- [ ] Verify that requests without a valid CSRF token are rejected with a 403.