### PR TITLE
fix: avoid empty assistant frame during streaming

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^4.0.4",
-    "@ai-sdk/gateway": "^4.0.7",
     "@ai-sdk/google": "^4.0.3",
     "@ai-sdk/openai": "^4.0.4",
     "@ai-sdk/vue": "^4.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@ai-sdk/anthropic':
         specifier: ^4.0.4
         version: 4.0.4(zod@4.4.3)
-      '@ai-sdk/gateway':
-        specifier: ^4.0.7
-        version: 4.0.7(zod@4.4.3)
       '@ai-sdk/google':
         specifier: ^4.0.3
         version: 4.0.3(zod@4.4.3)

--- a/server/routes/api/chats/[id].post.ts
+++ b/server/routes/api/chats/[id].post.ts
@@ -1,6 +1,5 @@
 import type { UIMessage } from 'ai'
 import { convertToModelMessages, createUIMessageStreamResponse, generateText, isStepCount, smoothStream, streamText, toUIMessageStream } from 'ai'
-import { gateway } from '@ai-sdk/gateway'
 import { z } from 'zod'
 import type { AnthropicLanguageModelOptions } from '@ai-sdk/anthropic'
 import { anthropic } from '@ai-sdk/anthropic'
@@ -44,7 +43,7 @@ export default defineHandler(async (event) => {
 
   if (!chat.title) {
     const { text: title } = await generateText({
-      model: gateway('openai/gpt-4.1-nano'),
+      model: 'openai/gpt-4.1-nano',
       instructions: `You are a title generator for a chat:
           - Generate a short title based on the first user's message
           - The title should be less than 30 characters long
@@ -72,7 +71,7 @@ export default defineHandler(async (event) => {
 
   const result = streamText({
     abortSignal: abortController.signal,
-    model: gateway(model),
+    model,
     instructions: `You are a knowledgeable and helpful AI assistant. ${session.data.user?.username ? `The user's name is ${session.data.user.username}.` : ''} Your goal is to provide clear, accurate, and well-structured responses.
 
 **FORMATTING RULES (CRITICAL):**

--- a/server/routes/api/chats/[id].post.ts
+++ b/server/routes/api/chats/[id].post.ts
@@ -1,5 +1,5 @@
 import type { UIMessage } from 'ai'
-import { convertToModelMessages, createUIMessageStream, createUIMessageStreamResponse, generateText, isStepCount, smoothStream, streamText, toUIMessageStream } from 'ai'
+import { convertToModelMessages, createUIMessageStreamResponse, generateText, isStepCount, smoothStream, streamText, toUIMessageStream } from 'ai'
 import { gateway } from '@ai-sdk/gateway'
 import { z } from 'zod'
 import type { AnthropicLanguageModelOptions } from '@ai-sdk/anthropic'
@@ -70,12 +70,10 @@ export default defineHandler(async (event) => {
   const abortController = new AbortController()
   event.runtime?.node?.req?.on('close', () => abortController.abort())
 
-  const stream = createUIMessageStream({
-    execute: async ({ writer }) => {
-      const result = streamText({
-        abortSignal: abortController.signal,
-        model: gateway(model),
-        instructions: `You are a knowledgeable and helpful AI assistant. ${session.data.user?.username ? `The user's name is ${session.data.user.username}.` : ''} Your goal is to provide clear, accurate, and well-structured responses.
+  const result = streamText({
+    abortSignal: abortController.signal,
+    model: gateway(model),
+    instructions: `You are a knowledgeable and helpful AI assistant. ${session.data.user?.username ? `The user's name is ${session.data.user.username}.` : ''} Your goal is to provide clear, accurate, and well-structured responses.
 
 **FORMATTING RULES (CRITICAL):**
 - ABSOLUTELY NO MARKDOWN HEADINGS: Never use #, ##, ###, ####, #####, or ######
@@ -97,58 +95,48 @@ export default defineHandler(async (event) => {
 - Use examples when helpful
 - Break down complex topics into digestible parts
 - Maintain a friendly, professional tone`,
-        messages: await convertToModelMessages(messages),
-        tools: {
-          chart: chartTool,
-          weather: weatherTool,
-          ...(model.startsWith('anthropic/') && { web_search: anthropic.tools.webSearch_20250305() }),
-          ...(model.startsWith('openai/') && { web_search: openai.tools.webSearch() })
-          // TODO: enable once AI SDK supports combining provider-defined tools with custom tools
-          // ...(model.startsWith('google/') && { google_search: google.tools.googleSearch({}) })
-        },
-        providerOptions: {
-          anthropic: {
-            thinking: {
-              type: 'enabled',
-              budgetTokens: 2048
-            }
-          } satisfies AnthropicLanguageModelOptions,
-          google: {
-            thinkingConfig: {
-              includeThoughts: true,
-              thinkingLevel: 'low'
-            }
-          } satisfies GoogleLanguageModelOptions,
-          openai: {
-            reasoningEffort: 'low',
-            reasoningSummary: 'detailed'
-          } satisfies OpenAILanguageModelResponsesOptions
-        },
-        stopWhen: isStepCount(5),
-        experimental_transform: smoothStream()
-      })
-
-      if (!chat.title) {
-        writer.write({
-          type: 'data-chat-title',
-          data: { message: 'Generating title...' },
-          transient: true
-        })
-      }
-
-      writer.merge(toUIMessageStream({
-        stream: result.stream,
-        sendSources: true,
-        sendReasoning: true
-      }))
+    messages: await convertToModelMessages(messages),
+    tools: {
+      chart: chartTool,
+      weather: weatherTool,
+      ...(model.startsWith('anthropic/') && { web_search: anthropic.tools.webSearch_20250305() }),
+      ...(model.startsWith('openai/') && { web_search: openai.tools.webSearch() })
+      // TODO: enable once AI SDK supports combining provider-defined tools with custom tools
+      // ...(model.startsWith('google/') && { google_search: google.tools.googleSearch({}) })
     },
-    onEnd: async ({ messages }) => {
-      await db.insert(tables.messages).values(messages.map(message => ({
-        id: message.id,
+    providerOptions: {
+      anthropic: {
+        thinking: {
+          type: 'enabled',
+          budgetTokens: 2048
+        }
+      } satisfies AnthropicLanguageModelOptions,
+      google: {
+        thinkingConfig: {
+          includeThoughts: true,
+          thinkingLevel: 'low'
+        }
+      } satisfies GoogleLanguageModelOptions,
+      openai: {
+        reasoningEffort: 'low',
+        reasoningSummary: 'detailed'
+      } satisfies OpenAILanguageModelResponsesOptions
+    },
+    stopWhen: isStepCount(5),
+    experimental_transform: smoothStream()
+  })
+
+  const stream = toUIMessageStream({
+    stream: result.stream,
+    sendSources: true,
+    sendReasoning: true,
+    onEnd: async ({ responseMessage }) => {
+      await db.insert(tables.messages).values([{
+        id: responseMessage.id,
         chatId: chat.id,
-        role: message.role as 'user' | 'assistant',
-        parts: message.parts
-      }))).onConflictDoNothing()
+        role: responseMessage.role as 'user' | 'assistant',
+        parts: responseMessage.parts
+      }]).onConflictDoNothing()
     }
   })
 

--- a/server/routes/api/chats/[id].post.ts
+++ b/server/routes/api/chats/[id].post.ts
@@ -130,6 +130,10 @@ export default defineHandler(async (event) => {
     sendSources: true,
     sendReasoning: true,
     onEnd: async ({ responseMessage }) => {
+      // Don't persist an empty assistant message (e.g. the stream was aborted
+      // before any content), otherwise it reloads as an empty frame.
+      if (!responseMessage.parts?.length) return
+
       await db.insert(tables.messages).values([{
         id: responseMessage.id,
         chatId: chat.id,

--- a/src/pages/chat/[id].vue
+++ b/src/pages/chat/[id].vue
@@ -53,11 +53,6 @@ const { messages, status, error, sendMessage, regenerate, stop } = useChat({
       model: model.value
     }
   }),
-  onData: (dataPart) => {
-    if (dataPart.type === 'data-chat-title') {
-      fetchChats()
-    }
-  },
   onError(error) {
     let message = error.message
     if (typeof message === 'string' && message[0] === '{') {
@@ -74,6 +69,15 @@ const { messages, status, error, sendMessage, regenerate, stop } = useChat({
       color: 'error',
       duration: 0
     })
+  }
+})
+
+// The title is generated server-side (and persisted) before streaming starts on
+// the first message; there's no in-stream signal, so refresh the chats list as
+// soon as the response begins streaming — the watch above then syncs `title`.
+watch(status, (value) => {
+  if (value === 'streaming' && !title.value && isOwner.value) {
+    fetchChats()
   }
 })
 


### PR DESCRIPTION
## Problem

On every message, a loading ("Thinking…") indicator flashed at the end of the streamed response, with a scroll jump.

The chat handler wrapped the model stream in `createUIMessageStream({ execute → writer.merge(toUIMessageStream(...)) })`. That wrapper's async `writer.merge` read-loop + double `handleUIMessageStreamFinish` pass surfaced the assistant message's `start` chunk before its first *content* part (`start-step`/reasoning), so `useChat` created an empty assistant message and `UChatMessages` showed its loading indicator until content arrived — reproducible on every response, amplified by extended thinking latency.

## Fix

Stream the model **directly** with `toUIMessageStream(result.stream)` (the same shape the Nuxt UI playground uses) and persist via its own `onEnd` callback:

```ts
const stream = toUIMessageStream({
  stream: result.stream,
  sendSources: true,
  sendReasoning: true,
  onEnd: async ({ responseMessage }) => {
    await db.insert(tables.messages).values([{ id: responseMessage.id, chatId: chat.id, role: …, parts: responseMessage.parts }]).onConflictDoNothing()
  }
})
return createUIMessageStreamResponse({ stream })
```

Without the wrapper there's no `writer` for the transient `data-chat-title`, so the client now refreshes the chats list on the first `streaming` transition instead — the title is generated and persisted server-side *before* streaming begins, so it's already available. `onData` handler removed accordingly.

No `@nuxt/ui` changes needed.

## Validation

`pnpm lint`, `pnpm typecheck`, and `pnpm vite build` pass.