### PR TITLE
fix: add a visible focus ring to the logo link

### DIFF
--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -74,7 +74,7 @@ defineShortcuts({
         <ULink
           v-if="!collapsed"
           to="/"
-          class="flex items-center gap-0.5"
+          class="flex items-center gap-0.5 outline-primary/25 focus-visible:outline-3 rounded-md"
         >
           <UIcon
             name="i-logos-vue"


### PR DESCRIPTION
The logo link had no focus style of its own, so tabbing to it fell back to the browser default. Adds the same treatment already shipping in `calendar`:

```
outline-primary/25 focus-visible:outline-3 rounded-md
```

No padding here, matching the sidebar variant in `calendar/app/components/AppSidebar.vue`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved keyboard focus visibility for the sidebar header link with a clearer outline and rounded styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->